### PR TITLE
style(triage): linguetta card__board flat + utility admin in nuova scheda

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -703,7 +703,8 @@
     }
 
     .card__board {
-      /* Uses --card-color from cards.css */
+      background-color: transparent;
+      color: var(--card-content-color);
     }
 
     .card__header {

--- a/app/views/my/menus/_utilities.html.erb
+++ b/app/views/my/menus/_utilities.html.erb
@@ -1,11 +1,11 @@
 <%= collapsible_nav_section "Utilities" do %>
     <% if Current.user.admin? %>
         <%= filter_place_menu_item "/motor", "Motor Admin", "shield", new_window: true, turbo: false %>
-        <%= filter_place_menu_item "/sidekiq", "Sidekiq", "server" %>
-        <%= filter_place_menu_item "/blazer", "Blazer", "chart" %>
-        <%= filter_place_menu_item "/rails/performance", "Performance", "speedometer" %>
+        <%= filter_place_menu_item "/sidekiq", "Sidekiq", "server", new_window: true %>
+        <%= filter_place_menu_item "/blazer", "Blazer", "chart", new_window: true %>
+        <%= filter_place_menu_item "/rails/performance", "Performance", "speedometer", new_window: true %>
     <% end %>
     <% if Current.user.email == "paolo.tassinari@hey.com" %>
-        <%= filter_place_menu_item "/admin", "Admin", "shield" %>
+        <%= filter_place_menu_item "/admin", "Admin", "shield", new_window: true %>
     <% end %>
 <% end %>


### PR DESCRIPTION
## Modifiche

Due commit indipendenti:

1. **`style(triage)`** — Rende `.cards--maybe .card__board` trasparente (solo testo colorato) invece dello sfondo pieno ereditato da `cards.css`. Con il `padding-block-start` dell'header, lo sfondo colorato creava un gap "galleggiante" tra il bordo della card e la linguetta nel triage. Allinea al comportamento di Fizzy.

2. **`style(menu)`** — Aggiunge `new_window: true` alle voci Sidekiq, Blazer, Performance e Admin del menu Utilities, così si aprono in una nuova scheda.

## Note

La modifica al triage è una prova visiva: se la linguetta flat non convince, basta ripristinare la regola vuota `/* Uses --card-color from cards.css */`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)